### PR TITLE
add warnings for sizes

### DIFF
--- a/keras_unet_collection/_model_unet_2d.py
+++ b/keras_unet_collection/_model_unet_2d.py
@@ -8,6 +8,8 @@ from keras_unet_collection._backbone_zoo import backbone_zoo, bach_norm_checker
 from tensorflow.keras.layers import Input
 from tensorflow.keras.models import Model
 
+import numpy as np 
+
 def UNET_left(X, channel, kernel_size=3, stack_num=2, activation='ReLU', l1=1e-2, l2=1e-2,
               pool=True, batch_norm=False, kernel_initializer='glorot_uniform', name='left0'):
     '''
@@ -311,6 +313,15 @@ def unet_2d(input_size, filter_num, n_labels, kernel_size=3,stack_num_down=2, st
     if backbone is not None:
         bach_norm_checker(backbone, batch_norm)
         
+    #check input size for power of 2
+    if (np.log2(input_size[0]).is_integer()) and (np.log2(input_size[1]).is_integer()):
+        pass
+    else:
+        print('WARNING: At least one of your input shapes are not a power of two.')
+        print('This might make things weird with maxpooling and concatenating the skip connections.')
+        print('Best to make your data to have power of 2s [e.g., 32, 64, 128, 256, 512]')
+        print('Your given input shape: ', input_size)
+
     IN = Input(input_size)
     
     # base    

--- a/keras_unet_collection/_model_unet_3plus_2d.py
+++ b/keras_unet_collection/_model_unet_3plus_2d.py
@@ -11,6 +11,8 @@ from tensorflow.keras.models import Model
 
 import warnings
 
+import numpy as np
+
 def unet_3plus_2d_base(input_tensor, filter_num_down, filter_num_skip, filter_num_aggregate, kernel_size=3, l1=1e-2, l2=1e-2,
                        stack_num_down=2, stack_num_up=1, activation='ReLU', batch_norm=False, pool=True, unpool=True, 
                        backbone=None, weights='imagenet', freeze_backbone=True, freeze_batch_norm=True, name='unet3plus'):
@@ -202,7 +204,7 @@ def unet_3plus_2d_base(input_tensor, filter_num_down, filter_num_skip, filter_nu
     # return decoder outputs
     return X_decoder
 
-def unet_3plus_2d(input_size, n_labels, filter_num_down, kernel_size=3, filter_num_skip='auto', filter_num_aggregate='auto', 
+def unet_3plus_2d(input_size, filter_num_down, n_labels, kernel_size=3, filter_num_skip='auto', filter_num_aggregate='auto', 
                   l1=1e-2, l2=1e-2, stack_num_down=2, stack_num_up=1, activation='ReLU', output_activation='Sigmoid',
                   batch_norm=False, pool=True, unpool=True, deep_supervision=False,
                   backbone=None, weights='imagenet', freeze_backbone=True, freeze_batch_norm=True, name='unet3plus'):
@@ -280,6 +282,20 @@ def unet_3plus_2d(input_size, n_labels, filter_num_down, kernel_size=3, filter_n
     '''
 
     depth_ = len(filter_num_down)
+
+    #check minimum depth:
+    if depth_ < 3:
+        print('WARNING: in order to setup all skip connections, a UNET3+ must have a minimum')
+        print('depth of 3. You gave a depth of: {}. To change this, change the len of your filter_num_down list.'.format(depth_))
+
+    #check input size for power of 2
+    if (np.log2(input_size[0]).is_integer()) and (np.log2(input_size[1]).is_integer()):
+        pass
+    else:
+        print('WARNING: At least one of your input shapes are not a power of two.')
+        print('This might make things weird with maxpooling and concatenating the skip connections.')
+        print('Best to make your data to have power of 2s [e.g., 32, 64, 128, 256, 512]')
+        print('Your given input shape: ', input_size)
     
     verbose = False
     

--- a/keras_unet_collection/_model_unet_plus_2d.py
+++ b/keras_unet_collection/_model_unet_plus_2d.py
@@ -10,6 +10,7 @@ from tensorflow.keras.layers import Input
 from tensorflow.keras.models import Model
 
 import warnings
+import numpy as np 
 
 def unet_plus_2d_base(input_tensor, filter_num, kernel_size=3, stack_num_down=2, stack_num_up=2, l1=1e-2,l2=1e-2,
                       activation='ReLU', batch_norm=False, pool=True, unpool=True, deep_supervision=False, 
@@ -237,8 +238,18 @@ def unet_plus_2d(input_size, filter_num, n_labels, kernel_size=3, stack_num_down
     
     if backbone is not None:
         bach_norm_checker(backbone, batch_norm)
+
+    #check input size for power of 2
+    if (np.log2(input_size[0]).is_integer()) and (np.log2(input_size[1]).is_integer()):
+        pass
+    else:
+        print('WARNING: At least one of your input shapes are not a power of two.')
+        print('This might make things weird with maxpooling and concatenating the skip connections.')
+        print('Best to make your data to have power of 2s [e.g., 32, 64, 128, 256, 512]')
+        print('Your given input shape: ', input_size)
     
     IN = Input(input_size)
+    
     # base
     X = unet_plus_2d_base(IN, filter_num, kernel_size=kernel_size, stack_num_down=stack_num_down, stack_num_up=stack_num_up, l1=l1, l2=l2, 
                           activation=activation, batch_norm=batch_norm, pool=pool, unpool=unpool, deep_supervision=deep_supervision, 


### PR DESCRIPTION
If not using power of 2s for dimensions, things can get weird after max pooling a few times. This is particularly important for the skip connections, since sometimes upsampling the data can result in mis-matching of dimensions. Thus, I added a simple check to see if the x and y dims are divisible by 2 and to then warn the user if they are or are not. 

Along these lines, UNET3+ requires a minimum depth of 3 in order to set up all the skip connections properly. Thus, a warning is now included to note if the depth of the network is not deep enough. 

Finally, I also changed the order of the unet_3plus_2d inputs to match unet_2d and unet_plus_2d:

Before

``def unet_3plus_2d(input_size, n_labels, filter_num_down ... ) ``

After 

`` def unet_3plus_2d(input_size, filter_num_down, n_labels, ... ) ``