### PR TITLE
add 3d conv

### DIFF
--- a/keras_unet_collection/_model_unet_3d.py
+++ b/keras_unet_collection/_model_unet_3d.py
@@ -1,0 +1,346 @@
+""" EXPERIMENTAL: YOUR MILAGE MAY VARY!
+This was a copy of the _model_unet_2d.py, but adapted to include 3d convolutions.
+
+Note that you can use this method to predict 3d maps, but often was the case in my work that I wanted a 2d map at the end
+
+Adapted by Randy J. Chase 
+
+"""
+
+from __future__ import absolute_import
+
+from keras_unet_collection.layer_utils_3d import *
+from keras_unet_collection.activations import GELU, Snake
+from keras_unet_collection._backbone_zoo import backbone_zoo, bach_norm_checker
+
+from tensorflow.keras.layers import Input,Reshape
+from tensorflow.keras.models import Model
+
+def UNET_left(X, channel, kernel_size=3, stack_num=2, activation='ReLU', l1=1e-2, l2=1e-2,
+              pool=True, batch_norm=False, kernel_initializer='glorot_uniform', name='left0',
+              pool_size=(2,2,2)):
+    '''
+    The encoder block of U-net.
+    
+    UNET_left(X, channel, kernel_size=3, stack_num=2, activation='ReLU', 
+              pool=True, batch_norm=False, name='left0')
+    
+    Input
+    ----------
+        X: input tensor.
+        channel: number of convolution filters.
+        kernel_size: size of 2-d convolution kernels.
+        stack_num: number of convolutional layers.
+        activation: one of the `tensorflow.keras.layers` interface, e.g., 'ReLU'.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        pool: True or 'max' for MaxPooling2D.
+              'ave' for AveragePooling2D.
+              False for strided conv + batch norm + activation.
+        batch_norm: True for batch normalization, False otherwise.
+        kernel_initializer: how initialize weights. 
+        name: prefix of the created keras layers.
+        
+    Output
+    ----------
+        X: output tensor.
+        
+    '''
+    
+    X = encode_layer(X, channel, pool_size, pool, activation=activation, l1=l1, l2=l2,
+                     batch_norm=batch_norm, kernel_initializer=kernel_initializer,
+                     name='{}_encode'.format(name))
+
+    X = CONV_stack(X, channel, kernel_size, stack_num=stack_num, activation=activation, l1=l1, l2=l2,
+                   batch_norm=batch_norm, kernel_initializer=kernel_initializer, 
+                   name='{}_conv'.format(name))
+    
+    return X
+
+
+def UNET_right(X, X_list, channel, kernel_size=3, l1=1e-2, l2=1e-2, stack_num=2, activation='ReLU',
+               unpool=True, batch_norm=False, concat=True, kernel_initializer='glorot_uniform',
+               name='right0',pool_size=(2,2,2)):
+    
+    '''
+    The decoder block of U-net.
+    
+    Input
+    ----------
+        X: input tensor.
+        X_list: a list of other tensors that connected to the input tensor.
+        channel: number of convolution filters.
+        kernel_size: size of 2-d convolution kernels.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        stack_num: number of convolutional layers.
+        activation: one of the `tensorflow.keras.layers` interface, e.g., 'ReLU'.
+        unpool: True or 'bilinear' for Upsampling2D with bilinear interpolation.
+                'nearest' for Upsampling2D with nearest interpolation.
+                False for Conv2DTranspose + batch norm + activation.
+        batch_norm: True for batch normalization, False otherwise.
+        concat: True for concatenating the corresponded X_list elements.
+        kernel_initializer: how initialize weights.
+        name: prefix of the created keras layers.
+        
+    Output
+    ----------
+        X: output tensor.
+    
+    '''
+    
+    X = decode_layer(X, channel, pool_size, unpool, l1=l1, l2=l2,
+                     activation=activation, batch_norm=batch_norm,kernel_initializer=kernel_initializer,
+                     name='{}_decode'.format(name))
+    
+    # linear convolutional layers before concatenation
+    X = CONV_stack(X, channel, kernel_size, stack_num=1, activation=activation, l1=l1, l2=l2,
+                   batch_norm=batch_norm, kernel_initializer=kernel_initializer,
+                   name='{}_conv_before_concat'.format(name))
+    if concat:
+        # <--- *stacked convolutional can be applied here
+        X = concatenate([X,]+X_list, axis=4, name=name+'_concat')
+    
+    # Stacked convolutions after concatenation 
+    X = CONV_stack(X, channel, kernel_size, stack_num=stack_num, activation=activation, l1=l1, l2=l2,
+                   batch_norm=batch_norm, kernel_initializer=kernel_initializer,
+                   name=name+'_conv_after_concat')
+    
+    return X
+
+def unet_3d_base(input_tensor, filter_num, kernel_size=3, stack_num_down=2, stack_num_up=2, 
+                 l1=1e-2, l2=1e-2, activation='ReLU', batch_norm=False, pool=True, unpool=True, 
+                 backbone=None, weights='imagenet', freeze_backbone=True, 
+                 freeze_batch_norm=True, kernel_initializer='glorot_uniform',
+                 name='unet',pool_size=(2,2,2)):
+    
+    '''
+    The base of U-net with an optional ImageNet-trained backbone.
+    
+    unet_3d_base(input_tensor, filter_num, stack_num_down=2, stack_num_up=2, 
+                 activation='ReLU', batch_norm=False, pool=True, unpool=True, 
+                 backbone=None, weights='imagenet', freeze_backbone=True, freeze_batch_norm=True, name='unet')
+    
+    ----------
+    Ronneberger, O., Fischer, P. and Brox, T., 2015, October. U-net: Convolutional networks for biomedical image segmentation. 
+    In International Conference on Medical image computing and computer-assisted intervention (pp. 234-241). Springer, Cham.
+    
+    Input
+    ----------
+        input_tensor: the input tensor of the base, e.g., `keras.layers.Inpyt((None, None, 3))`.
+        filter_num: a list that defines the number of filters for each \
+                    down- and upsampling levels. e.g., `[64, 128, 256, 512]`.
+                    The depth is expected as `len(filter_num)`.
+        kernel_size: number of the size of the convolutional kernel within the convolutions.
+        stack_num_down: number of convolutional layers per downsampling level/block. 
+        stack_num_up: number of convolutional layers (after concatenation) per upsampling level/block.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        activation: one of the `tensorflow.keras.layers` or `keras_unet_collection.activations` interfaces, e.g., 'ReLU'.
+        batch_norm: True for batch normalization.
+        pool: True or 'max' for MaxPooling2D.
+              'ave' for AveragePooling2D.
+              False for strided conv + batch norm + activation.
+        unpool: True or 'bilinear' for Upsampling2D with bilinear interpolation.
+                'nearest' for Upsampling2D with nearest interpolation.
+                False for Conv2DTranspose + batch norm + activation.
+        kernel_initializer: how initialize weights.
+        name: prefix of the created keras model and its layers.
+        
+        ---------- (keywords of backbone options) ----------
+        backbone_name: the bakcbone model name. Should be one of the `tensorflow.keras.applications` class.
+                       None (default) means no backbone. 
+                       Currently supported backbones are:
+                       (1) VGG16, VGG19
+                       (2) ResNet50, ResNet101, ResNet152
+                       (3) ResNet50V2, ResNet101V2, ResNet152V2
+                       (4) DenseNet121, DenseNet169, DenseNet201
+                       (5) EfficientNetB[0-7]
+        weights: one of None (random initialization), 'imagenet' (pre-training on ImageNet), 
+                 or the path to the weights file to be loaded.
+        freeze_backbone: True for a frozen backbone.
+        freeze_batch_norm: False for not freezing batch normalization layers.
+        
+    Output
+    ----------
+        X: output tensor.
+    
+    '''
+    
+    activation_func = eval(activation)
+
+    X_skip = []
+    depth_ = len(filter_num)
+
+    # no backbone cases
+    if backbone is None:
+
+        X = input_tensor
+
+        # stacked conv2d before downsampling
+        X = CONV_stack(X, filter_num[0], kernel_size=kernel_size, stack_num=stack_num_down, l1=l1, l2=l2,
+                        activation=activation, batch_norm=batch_norm, kernel_initializer=kernel_initializer,
+                        name='{}_down0'.format(name))
+
+        X_skip.append(X)
+
+        # downsampling blocks
+        for i, f in enumerate(filter_num[1:]):
+            X = UNET_left(X, f, kernel_size=kernel_size,stack_num=stack_num_down, l1=l1, l2=l2,
+                        activation=activation, pool=pool, batch_norm=batch_norm,kernel_initializer=kernel_initializer,
+                        name='{}_down{}'.format(name, i+1),pool_size=pool_size)        
+            X_skip.append(X)
+
+    # backbone cases
+    else:
+        # handling VGG16 and VGG19 separately
+        if 'VGG' in backbone:
+            backbone_ = backbone_zoo(backbone, weights, input_tensor, depth_, freeze_backbone, freeze_batch_norm)
+            # collecting backbone feature maps
+            X_skip = backbone_([input_tensor,])
+            depth_encode = len(X_skip)
+            
+        # for other backbones
+        else:
+            backbone_ = backbone_zoo(backbone, weights, input_tensor, depth_-1, freeze_backbone, freeze_batch_norm)
+            # collecting backbone feature maps
+            X_skip = backbone_([input_tensor,])
+            depth_encode = len(X_skip) + 1
+
+
+        # extra conv2d blocks are applied
+        # if downsampling levels of a backbone < user-specified downsampling levels
+        if depth_encode < depth_:
+
+            # begins at the deepest available tensor  
+            X = X_skip[-1]
+
+            # extra downsamplings
+            for i in range(depth_-depth_encode):
+                i_real = i + depth_encode
+
+                X = UNET_left(X, filter_num[i_real],kernel_size=kernel_size, stack_num=stack_num_down, 
+                                l1=l1, l2=l2, activation=activation, pool=pool, 
+                                batch_norm=batch_norm, kernel_initializer=kernel_initializer,
+                                name='{}_down{}'.format(name, i_real+1),pool_size=pool_size)
+                X_skip.append(X)
+
+    # reverse indexing encoded feature maps
+    X_skip = X_skip[::-1]
+    # upsampling begins at the deepest available tensor
+    X = X_skip[0]
+    # other tensors are preserved for concatenation
+    X_decode = X_skip[1:]
+    depth_decode = len(X_decode)
+
+    # reverse indexing filter numbers
+    filter_num_decode = filter_num[:-1][::-1]
+
+    # upsampling with concatenation
+    for i in range(depth_decode):
+        X = UNET_right(X, [X_decode[i],], filter_num_decode[i], kernel_size=kernel_size, stack_num=stack_num_up, 
+                        activation=activation, unpool=unpool, batch_norm=batch_norm, kernel_initializer=kernel_initializer,
+                        l1=l1, l2=l2, name='{}_up{}'.format(name, i),pool_size=pool_size)
+
+    # if tensors for concatenation is not enough
+    # then use upsampling without concatenation 
+    if depth_decode < depth_-1:
+        for i in range(depth_-depth_decode-1):
+            i_real = i + depth_decode
+            X = UNET_right(X, None, filter_num_decode[i_real],kernel_size=kernel_size, stack_num=stack_num_up,
+                            activation=activation, unpool=unpool, batch_norm=batch_norm, 
+                            concat=False, kernel_initializer=kernel_initializer,
+                            l1=l1, l2=l2, name='{}_up{}'.format(name, i_real),pool_size=pool_size)   
+    return X
+
+def unet_3d(input_size, filter_num, n_labels, kernel_size=3,stack_num_down=2, stack_num_up=2, l1=1e-2, l2=1e-2,
+            activation='ReLU', output_activation='Softmax', batch_norm=False, pool=True, unpool=True, 
+            backbone=None, weights='imagenet', freeze_backbone=True, freeze_batch_norm=True, 
+            kernel_initializer='glorot_uniform', name='unet',collapse=True,pool_size=(2,2,2)):
+    '''
+    U-net with an optional ImageNet-trained backbone.
+    
+    unet_3d(input_size, filter_num, n_labels, kernel_size=3, stack_num_down=2, stack_num_up=2,
+            activation='ReLU', output_activation='Softmax', batch_norm=False, pool=True, unpool=True, 
+            backbone=None, weights='imagenet', freeze_backbone=True, freeze_batch_norm=True, name='unet')
+    
+    ----------
+    Ronneberger, O., Fischer, P. and Brox, T., 2015, October. U-net: Convolutional networks for biomedical image segmentation. 
+    In International Conference on Medical image computing and computer-assisted intervention (pp. 234-241). Springer, Cham.
+    
+    Input
+    ----------
+        input_size: the size/shape of network input, e.g., `(128, 128, 3)`.
+        filter_num: a list that defines the number of filters for each \
+                    down- and upsampling levels. e.g., `[64, 128, 256, 512]`.
+                    The depth is expected as `len(filter_num)`.
+        n_labels: number of output labels.
+        kernel_size: number of the size of the convolutional kernel within the convolutions.
+        stack_num_down: number of convolutional layers per downsampling level/block. 
+        stack_num_up: number of convolutional layers (after concatenation) per upsampling level/block.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        activation: one of the `tensorflow.keras.layers` or `keras_unet_collection.activations` interfaces, e.g., 'ReLU'.
+        output_activation: one of the `tensorflow.keras.layers` or `keras_unet_collection.activations` interface or 'Sigmoid'.
+                           Default option is 'Softmax'.
+                           if None is received, then linear activation is applied.
+        batch_norm: True for batch normalization.
+        pool: True or 'max' for MaxPooling2D.
+              'ave' for AveragePooling2D.
+              False for strided conv + batch norm + activation.
+        unpool: True or 'bilinear' for Upsampling2D with bilinear interpolation.
+                'nearest' for Upsampling2D with nearest interpolation.
+                False for Conv2DTranspose + batch norm + activation.
+        kernel_initializer: how initialize weights.                 
+        name: prefix of the created keras model and its layers.
+        
+        ---------- (keywords of backbone options) ----------
+        backbone_name: the bakcbone model name. Should be one of the `tensorflow.keras.applications` class.
+                       None (default) means no backbone. 
+                       Currently supported backbones are:
+                       (1) VGG16, VGG19
+                       (2) ResNet50, ResNet101, ResNet152
+                       (3) ResNet50V2, ResNet101V2, ResNet152V2
+                       (4) DenseNet121, DenseNet169, DenseNet201
+                       (5) EfficientNetB[0-7]
+        weights: one of None (random initialization), 'imagenet' (pre-training on ImageNet), 
+                 or the path to the weights file to be loaded.
+        freeze_backbone: True for a frozen backbone.
+        freeze_batch_norm: False for not freezing batch normalization layers.
+        
+    Output
+    ----------
+        model: a keras model.
+    
+    '''
+    activation_func = eval(activation)
+    
+    if backbone is not None:
+        bach_norm_checker(backbone, batch_norm)
+        
+    IN = Input(input_size)
+    
+    # base    
+    X = unet_3d_base(IN, filter_num, kernel_size=kernel_size,stack_num_down=stack_num_down, stack_num_up=stack_num_up, 
+                     activation=activation, batch_norm=batch_norm, pool=pool, unpool=unpool, l1=l1, l2=l2,
+                     backbone=backbone, weights=weights, freeze_backbone=freeze_backbone, 
+                     freeze_batch_norm=freeze_backbone, kernel_initializer=kernel_initializer,
+                     pool_size=pool_size,name=name)
+
+    if collapse:
+        #use valid padding to collapse third dim down and keep same number of filters 
+        X = Conv3D(X.type_spec.shape[-1],kernel_size=(1, 1,input_size[2]),activation=activation,padding='valid',name='ConvolveAndCollapse')(X)
+
+    
+    # output layer
+    OUT = CONV_output(X, n_labels, kernel_size=1, activation=output_activation, 
+                        l1=l1, l2=l2, kernel_initializer=kernel_initializer,name='{}_output'.format(name))
+    
+    if collapse:
+        #get rid of 3rd dim where it is just a 1, orig shape should be [none,nx,ny,1,n_labels]
+        OUT = Reshape([X.type_spec.shape[1],X.type_spec.shape[2],n_labels],name='squeeze')(OUT)
+
+    # functional API model
+    model = Model(inputs=[IN,], outputs=[OUT,], name='{}_model'.format(name))
+    
+    return model

--- a/keras_unet_collection/layer_utils_3d.py
+++ b/keras_unet_collection/layer_utils_3d.py
@@ -1,0 +1,250 @@
+""" EXPERIMENTAL: YOUR MILAGE MAY VARY!
+This was a copy of the layer_utils.py, but adapted to include 3d convolutions.
+    Adapted by Randy J. Chase 
+"""
+from __future__ import absolute_import
+
+from keras_unet_collection.activations import GELU, Snake
+from tensorflow import expand_dims
+from tensorflow.compat.v1 import image
+from tensorflow.keras.layers import MaxPooling3D, AveragePooling3D, UpSampling3D, Conv3DTranspose, GlobalAveragePooling3D
+from tensorflow.keras.layers import Conv3D, Lambda
+from tensorflow.keras.layers import BatchNormalization, Activation, concatenate, multiply, add
+from tensorflow.keras.layers import ReLU, LeakyReLU, PReLU, ELU, Softmax
+from tensorflow.keras import regularizers
+
+def decode_layer(X, channel, pool_size, unpool, kernel_size=3, l1=1e-2, l2=1e-2,
+                 activation='ReLU', batch_norm=False,kernel_initializer='glorot_uniform',
+                 name='decode'):
+    '''
+    An overall decode layer, based on either upsampling or trans conv.
+    
+    decode_layer(X, channel, pool_size, unpool, kernel_size=3,
+                 activation='ReLU', batch_norm=False, name='decode')
+    
+    Input
+    ----------
+        X: input tensor.
+        pool_size: the decoding factor.
+        channel: (for trans conv only) number of convolution filters.
+        unpool: True or 'bilinear' for Upsampling2D with bilinear interpolation.
+                'nearest' for Upsampling2D with nearest interpolation.
+                False for Conv2DTranspose + batch norm + activation.           
+        kernel_size: size of convolution kernels. 
+                     If kernel_size='auto', then it equals to the `pool_size`.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        activation: one of the `tensorflow.keras.layers` interface, e.g., ReLU.
+        batch_norm: True for batch normalization, False otherwise.
+        name: prefix of the created keras layers.
+        
+    Output
+    ----------
+        X: output tensor.
+    
+    * The defaut: `kernel_size=3`, is suitable for `pool_size=2`.
+    
+    '''
+    # parsers
+    if unpool is False:
+        # trans conv configurations
+        bias_flag = not batch_norm
+    
+    elif unpool == 'nearest':
+        # upsample2d configurations
+        unpool = True
+        interp = 'nearest'
+    
+    elif (unpool is True) or (unpool == 'bilinear'):
+        # upsample2d configurations
+        unpool = True
+        interp = 'bilinear'
+    
+    else:
+        raise ValueError('Invalid unpool keyword')
+        
+    if unpool:
+        #will need to change this if not wanting to upsample 3rd dim. RJC 10/04/22
+        X = UpSampling3D(size=pool_size, name='{}_unpool'.format(name))(X)
+    else:
+        if kernel_size == 'auto':
+            kernel_size = pool_size
+            #probably doesnt work here... RJC 10/4/22
+        X = Conv2DTranspose(channel, kernel_size, strides=(pool_size, pool_size, pool_size), 
+                            kernel_regularizer=regularizers.L1L2(l1=l1, l2=l2),
+                            padding='same', kernel_initializer=kernel_initializer,
+                            name='{}_trans_conv'.format(name))(X)
+        
+        # batch normalization
+        if batch_norm:
+            X = BatchNormalization(axis=4, name='{}_bn'.format(name))(X)
+            
+        # activation
+        if activation is not None:
+            activation_func = eval(activation)
+            X = activation_func(name='{}_activation'.format(name))(X)
+        
+    return X
+
+def encode_layer(X, channel, pool_size, pool, kernel_size='auto', l1=1e-2, l2=1e-2,
+                 activation='ReLU', batch_norm=False, kernel_initializer='glorot_uniform',
+                 name='encode'):
+    '''
+    An overall encode layer, based on one of the:
+    (1) max-pooling, (2) average-pooling, (3) strided conv2d.
+    
+    encode_layer(X, channel, pool_size, pool, kernel_size='auto', 
+                 activation='ReLU', batch_norm=False, name='encode')
+    
+    Input
+    ----------
+        X: input tensor.
+        pool_size: the encoding factor.
+        channel: (for strided conv only) number of convolution filters.
+        pool: True or 'max' for MaxPooling2D.
+              'ave' for AveragePooling2D.
+              False for strided conv + batch norm + activation.
+        kernel_size: size of convolution kernels. 
+                     If kernel_size='auto', then it equals to the `pool_size`.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        activation: one of the `tensorflow.keras.layers` interface, e.g., ReLU.
+        batch_norm: True for batch normalization, False otherwise.
+        name: prefix of the created keras layers.
+        
+    Output
+    ----------
+        X: output tensor.
+        
+    '''
+    # parsers
+    if (pool in [False, True, 'max', 'ave']) is not True:
+        raise ValueError('Invalid pool keyword')
+        
+    # maxpooling2d as default
+    if pool is True:
+        pool = 'max'
+        
+    elif pool is False:
+        # stride conv configurations
+        bias_flag = not batch_norm
+    
+    if pool == 'max':
+        X = MaxPooling3D(pool_size=pool_size, name='{}_maxpool'.format(name))(X)
+        
+    elif pool == 'ave':
+        X = AveragePooling3D(pool_size=pool_size, name='{}_avepool'.format(name))(X)
+        
+    else:
+        if kernel_size == 'auto':
+            kernel_size = pool_size
+        
+        # linear convolution with strides !Probably doesnt work RJC 10/4/22
+        X = Conv2D(channel, kernel_size, strides=(pool_size, pool_size,pool_size), 
+                   kernel_regularizer=regularizers.L1L2(l1=l1, l2=l2),
+                   padding='valid', use_bias=bias_flag,kernel_initializer=kernel_initializer,
+                   name='{}_stride_conv'.format(name))(X)
+        
+        
+        if batch_norm:
+            X = BatchNormalization(axis=4, name='{}_bn'.format(name))(X)
+            
+        # activation
+        if activation is not None:
+            activation_func = eval(activation)
+            X = activation_func(name='{}_activation'.format(name))(X)
+            
+    return X
+
+def CONV_stack(X, channel, kernel_size=3, stack_num=2, dilation_rate=1, l1=1e-2, l2=1e-2, activation='ReLU',batch_norm=False, 
+                    kernel_initializer='glorot_uniform',name='conv_stack'):
+    '''
+    Stacked convolutional layers:
+    (Convolutional layer --> batch normalization --> Activation)*stack_num
+    
+    CONV_stack(X, channel, kernel_size=3, stack_num=2, dilation_rate=1, activation='ReLU', 
+               batch_norm=False, name='conv_stack')
+    
+    
+    Input
+    ----------
+        X: input tensor.
+        channel: number of convolution filters.
+        kernel_size: size of 2-d convolution kernels.
+        stack_num: number of stacked Conv2D-BN-Activation layers.
+        dilation_rate: optional dilated convolution kernel.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        activation: one of the `tensorflow.keras.layers` interface, e.g., ReLU.
+        batch_norm: True for batch normalization, False otherwise.
+        kernel_initializer: how to initialize kernels. By defualt uses the default Conv. init. 
+        name: prefix of the created keras layers.
+        
+    Output
+    ----------
+        X: output tensor
+        
+    '''
+    
+    bias_flag = not batch_norm
+    
+    # stacking Convolutional layers
+    for i in range(stack_num):
+        
+        activation_func = eval(activation)
+        
+        # linear convolution
+        X = Conv3D(channel, kernel_size, padding='same', use_bias=bias_flag, 
+                   kernel_regularizer=regularizers.L1L2(l1=l1, l2=l2), 
+                   dilation_rate=dilation_rate, kernel_initializer=kernel_initializer,
+                   name='{}_{}'.format(name, i))(X)
+        
+        # batch normalization
+        if batch_norm:
+            X = BatchNormalization(axis=4, name='{}_{}_bn'.format(name, i))(X)
+        
+        # activation
+        activation_func = eval(activation)
+        X = activation_func(name='{}_{}_activation'.format(name, i))(X)
+        
+    return X
+
+def CONV_output(X, n_labels, kernel_size=1, l1=1e-2, l2=1e-2, activation='Softmax',kernel_initializer='glorot_uniform',
+                    name='conv_output'):
+    '''
+    Convolutional layer with output activation.
+    
+    CONV_output(X, n_labels, kernel_size=1, activation='Softmax', name='conv_output')
+    
+    Input
+    ----------
+        X: input tensor.
+        n_labels: number of classification label(s).
+        kernel_size: size of 2-d convolution kernels. Default is 1-by-1.
+        l1: the l1 regularization penalty used in kernel regularization
+        l2: the l2 regularization penalty used in kernel regularization
+        activation: one of the `tensorflow.keras.layers` or `keras_unet_collection.activations` interface or 'Sigmoid'.
+                    Default option is 'Softmax'.
+                    if None is received, then linear activation is applied.
+        name: prefix of the created keras layers.
+        
+    Output
+    ----------
+        X: output tensor.
+        
+    '''
+    
+    X = Conv3D(n_labels, kernel_size, padding='same', use_bias=True, kernel_initializer=kernel_initializer,
+                    kernel_regularizer=regularizers.L1L2(l1=l1, l2=l2), name=name)(X)
+    
+    if activation:
+        
+        if activation == 'Sigmoid':
+            X = Activation('sigmoid', name='{}_activation'.format(name))(X)
+            
+        else:
+            activation_func = eval(activation)
+            X = activation_func(name='{}_activation'.format(name))(X)
+            
+    return X
+

--- a/keras_unet_collection/models.py
+++ b/keras_unet_collection/models.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from keras_unet_collection._model_unet_2d import unet_2d
+from keras_unet_collection._model_unet_3d import unet_3d
 from keras_unet_collection._model_vnet_2d import vnet_2d
 from keras_unet_collection._model_unet_plus_2d import unet_plus_2d
 from keras_unet_collection._model_r2_unet_2d import r2_unet_2d
@@ -9,5 +10,6 @@ from keras_unet_collection._model_att_unet_2d import att_unet_2d
 from keras_unet_collection._model_resunet_a_2d import resunet_a_2d
 from keras_unet_collection._model_u2net_2d import u2net_2d
 from keras_unet_collection._model_unet_3plus_2d import unet_3plus_2d
+from keras_unet_collection._model_unet_3plus_3d import unet_3plus_3d
 from keras_unet_collection._model_transunet_2d import transunet_2d
 from keras_unet_collection._model_swin_unet_2d import swin_unet_2d


### PR DESCRIPTION
This push is for the first addition of 3D convolutions for unet and unet 3+. 

The way this was implemented was by creating 3 new scripts named:

1. _model_unet_3d
2. _model_unet_3plus_3d 
3. layer_utils_3d 

These new scripts are copies of their 2d counterparts, and then the Conv2D is replaced with Conv3D. Also there is an optional 'collapse' argument that will allow users to have 3d input, but only 2d out (e.g., a map). 

This is the initial push, so likely to be errors. 